### PR TITLE
Fix normalizing an exception that wraps a throwable

### DIFF
--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -14,6 +14,8 @@
 
 namespace InterfaSys\LogNormalizer;
 
+use Throwable;
+
 /**
  * Converts any variable to a String
  *
@@ -252,7 +254,7 @@ class Normalizer {
 	 */
 	private function normalizeObject($data, $depth) {
 		if (is_object($data)) {
-			if ($data instanceof \Exception) {
+			if ($data instanceof Throwable) {
 				return $this->normalizeException($data);
 			}
 			// We don't need to go too deep in the recursion
@@ -275,11 +277,11 @@ class Normalizer {
 	/**
 	 * Converts an Exception to String
 	 *
-	 * @param \Exception $exception
+	 * @param Throwable $exception
 	 *
 	 * @return string[]
 	 */
-	private function normalizeException(\Exception $exception) {
+	private function normalizeException(Throwable $exception) {
 		$data = [
 			'class'   => get_class($exception),
 			'message' => $exception->getMessage(),

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -15,7 +15,9 @@
 
 namespace InterfaSys\LogNormalizer;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 use function get_class;
 
 /**
@@ -307,6 +309,35 @@ class NormalizerTest extends TestCase {
 				]
 			], $normalized
 		);
+	}
+
+	public function testFormatExceptionWithPreviousThrowable() {
+		$t = new TypeError("not a type error");
+		$e = new Exception("an exception", 13, $t);
+
+		$normalized = $this->normalizer->normalize([
+			'exception' => $e,
+		]);
+
+		self::assertEquals(
+			[
+				'exception' => [
+					'class'   => get_class($e),
+					'message' => $e->getMessage(),
+					'code'    => $e->getCode(),
+					'file'    => $e->getFile() . ':' . $e->getLine(),
+					'trace'   => $e->getTraceAsString(),
+					'previous' => [
+						'class' => 'TypeError',
+						'message' => 'not a type error',
+						'code' => 0,
+						'file' => $t->getFile() . ':' . $t->getLine(),
+						'trace' => $t->getTraceAsString(),
+					]
+				]
+			], $normalized
+		);
+		self::assertTrue(isset($normalized['exception']['previous']));
 	}
 
 	public function testUnknown() {


### PR DESCRIPTION
The normalizer can take nested exceptions. But it fails hard on an exception that contains a previous throwable.

Seen in

* https://github.com/nextcloud/mail/issues/4063#issuecomment-727588050
* https://help.nextcloud.com/t/apps-mail-error-loading-mail-messages-typeerror-argument-1-passed-to-interfasys-lognormalizer-normalizer/99739/3
* https://help.nextcloud.com/t/typeerror-argument-1-passed-to-inter/98193
* https://help.nextcloud.com/t/typeerror-argument-7-passed-to-oca/98799/4